### PR TITLE
在选择或取消model或dao包路径后，主界面重新聚焦

### DIFF
--- a/src/cn/kt/ui/MainUI.java
+++ b/src/cn/kt/ui/MainUI.java
@@ -221,6 +221,7 @@ public class MainUI extends JFrame {
             final PsiPackage psiPackage = chooser.getSelectedPackage();
             String packageName = psiPackage == null ? null : psiPackage.getQualifiedName();
             modelPackageField.setText(packageName);
+            MainUI.this.toFront();
         });
         modelPackagePanel.add(packageBtn1);
 
@@ -246,6 +247,7 @@ public class MainUI extends JFrame {
             final PsiPackage psiPackage = chooser.getSelectedPackage();
             String packageName = psiPackage == null ? null : psiPackage.getQualifiedName();
             daoPackageField.setText(packageName);
+            MainUI.this.toFront();
         });
         daoPackagePanel.add(packageBtn2);
 


### PR DESCRIPTION
## 解决问题
主界面设置model和dao包路径后，主界面不可见，需要重新切换和激活。